### PR TITLE
Convert MaxxFan custom outputs to external component

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ The schematics and PCB are a prototype!!!  Please do not try to use as-is.  Late
 - This repository now uses a proper external component implementation in `/homeassistant/esphome/components/maxxfan/`
 - The original `custom_outputs.h` file is preserved for historical reference
 - Both the simplified MaxxFan-only configuration (`maxxfan-lite.yaml`) and the full configuration with AC control use this new external component structure
+- **Important**: You need to update the GPIO pin configurations in your YAML file to match the pins you're using on your ESP32. Look for the `globals` section with variables like `gpio_up_pin`, `gpio_down_pin`, etc. and set them to your specific pin numbers.
 
 ## Notes
 

--- a/README.md
+++ b/README.md
@@ -41,11 +41,23 @@ The schematics and PCB are a prototype!!!  Please do not try to use as-is.  Late
   - `/esphome/` - ESPHome configuration and custom components
     - `maxxfan.yaml` - Full configuration with MaxxFan and AC control
     - `maxxfan-lite.yaml` - Simplified configuration for MaxxFan only
-    - `custom_outputs.h` - Custom C++ code for MaxxFan control
+    - `custom_outputs.h` - Historical C++ code for MaxxFan control (using deprecated custom components)
+    - `/components/maxxfan/` - External component implementation for ESPHome 2025.3.3+ compatibility
+      - `__init__.py` - Python module for component registration
+      - `output.py` - Output component registration
+      - `maxxfan_output.h` - C++ header with output implementations
+      - `maxxfan_output.cpp` - C++ implementation file
   - `/www/` - Web assets for Lovelace UI customization
 - `/MaxxFan-Controller-Lite/` - Contains the MaxxFan-Controller-Lite hardware files designed in Fusion 360
   - You can order the [MaxxFan only boards on PCBWay](https://www.pcbway.com/project/shareproject/W829927AS1Y4_WALTERS_schematic_v24_2025_01_10_53f183b7.html)
 - And the PCB design files for the MaxxFan + Houghton AC are hosted separately on [OSH Lab](https://oshwlab.com/ncarney/maxxfan-controller)
+
+## ESPHome Compatibility Notes
+
+- ESPHome 2025.3.3 removed support for the "custom" component type
+- This repository now uses a proper external component implementation in `/homeassistant/esphome/components/maxxfan/`
+- The original `custom_outputs.h` file is preserved for historical reference
+- Both the simplified MaxxFan-only configuration (`maxxfan-lite.yaml`) and the full configuration with AC control use this new external component structure
 
 ## Notes
 

--- a/homeassistant/esphome/components/maxxfan/__init__.py
+++ b/homeassistant/esphome/components/maxxfan/__init__.py
@@ -1,0 +1,63 @@
+"""MaxxFan controller component for ESPHome."""
+
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.const import CONF_ID
+
+# Define the component namespace
+maxxfan_ns = cg.esphome_ns.namespace("maxxfan")
+
+# Define component variables
+CONF_GPIO_UP_PIN = "gpio_up_pin"
+CONF_GPIO_DOWN_PIN = "gpio_down_pin"
+CONF_GPIO_POWER_PIN = "gpio_power_pin"
+CONF_GPIO_DIRECTION_PIN = "gpio_direction_pin"
+CONF_GPIO_AUTO_PIN = "gpio_auto_pin"
+CONF_ACTUAL_FAN_SPEED = "actual_fan_speed"
+CONF_ACTUAL_FAN_POWER = "actual_fan_power"
+CONF_ACTUAL_FAN_DIRECTION = "actual_fan_direction"
+CONF_ACTUAL_FAN_COVER = "actual_fan_cover"
+CONF_IS_BOOT_FINISHED = "is_boot_finished"
+
+# Define component configuration schema
+CONFIG_SCHEMA = cv.Schema({})
+
+# Setup global variables for the component
+gpio_up_pin = maxxfan_ns.declare_variable(cg.int_, "gpio_up_pin")
+gpio_down_pin = maxxfan_ns.declare_variable(cg.int_, "gpio_down_pin")
+gpio_power_pin = maxxfan_ns.declare_variable(cg.int_, "gpio_power_pin")
+gpio_direction_pin = maxxfan_ns.declare_variable(cg.int_, "gpio_direction_pin")
+gpio_auto_pin = maxxfan_ns.declare_variable(cg.int_, "gpio_auto_pin")
+actual_fan_speed = maxxfan_ns.declare_variable(cg.int_, "actual_fan_speed")
+actual_fan_power = maxxfan_ns.declare_variable(cg.bool_, "actual_fan_power")
+actual_fan_direction = maxxfan_ns.declare_variable(cg.bool_, "actual_fan_direction")
+actual_fan_cover = maxxfan_ns.declare_variable(cg.bool_, "actual_fan_cover")
+is_boot_finished = maxxfan_ns.declare_variable(cg.bool_, "is_boot_finished")
+
+# Define async_setup function (will be called by ESPHome)
+async def async_setup(config):
+    # Get references to global variables from YAML
+    var1 = await cg.get_variable(cg.global_ns.namespace("gpio_up_pin"))
+    var2 = await cg.get_variable(cg.global_ns.namespace("gpio_down_pin"))
+    var3 = await cg.get_variable(cg.global_ns.namespace("gpio_power_pin"))
+    var4 = await cg.get_variable(cg.global_ns.namespace("gpio_direction_pin"))
+    var5 = await cg.get_variable(cg.global_ns.namespace("gpio_auto_pin"))
+    var6 = await cg.get_variable(cg.global_ns.namespace("actual_fan_speed"))
+    var7 = await cg.get_variable(cg.global_ns.namespace("actual_fan_power"))
+    var8 = await cg.get_variable(cg.global_ns.namespace("actual_fan_direction"))
+    var9 = await cg.get_variable(cg.global_ns.namespace("actual_fan_cover"))
+    var10 = await cg.get_variable(cg.global_ns.namespace("is_boot_finished"))
+    
+    # Link YAML globals to component globals
+    cg.add(gpio_up_pin.set(var1))
+    cg.add(gpio_down_pin.set(var2))
+    cg.add(gpio_power_pin.set(var3))
+    cg.add(gpio_direction_pin.set(var4))
+    cg.add(gpio_auto_pin.set(var5))
+    cg.add(actual_fan_speed.set(var6))
+    cg.add(actual_fan_power.set(var7))
+    cg.add(actual_fan_direction.set(var8))
+    cg.add(actual_fan_cover.set(var9))
+    cg.add(is_boot_finished.set(var10))
+    
+    return True

--- a/homeassistant/esphome/components/maxxfan/maxxfan_output.cpp
+++ b/homeassistant/esphome/components/maxxfan/maxxfan_output.cpp
@@ -1,0 +1,142 @@
+#include "maxxfan_output.h"
+#include "esphome/core/log.h"
+#include "esphome/core/application.h"
+#include "esphome/components/switch/switch.h"
+#include "Arduino.h"  // Add this for pinMode, digitalWrite, HIGH, LOW, etc.
+
+namespace esphome {
+namespace maxxfan {
+
+static const char *TAG = "maxxfan";
+
+// Define global variables
+int gpio_up_pin = 0;
+int gpio_down_pin = 0;
+int gpio_power_pin = 0;
+int gpio_direction_pin = 0;
+int gpio_auto_pin = 0;
+int actual_fan_speed = 4;
+bool actual_fan_power = false;
+bool actual_fan_direction = true;
+bool actual_fan_cover = false;
+bool is_boot_finished = false;
+
+// Define external access to the switch entity for publishing state
+namespace {
+  switch_::Switch *maxxfan_cover = nullptr;
+}
+
+void SpeedOutput::setup() {
+  pinMode(gpio_up_pin, OUTPUT);
+  pinMode(gpio_down_pin, OUTPUT);
+  ESP_LOGD(TAG, "SpeedOutput setup complete");
+}
+
+void SpeedOutput::write_state(float state) {
+  // state is a floating point number 0.0 to 1.0
+  // convert it to an integer from 0 to 10
+  int FanSet = state * 10;
+  // Don't do anything if still booting, or if request already matches actual,
+  // or if power is turned off, or if UI is setting 0 speed (which means off).
+  if (FanSet == 0 || FanSet == actual_fan_speed || actual_fan_power == 0 || !is_boot_finished)
+    return; // Do nothing
+  else if (FanSet > actual_fan_speed) {
+    while ((FanSet > actual_fan_speed) && (actual_fan_speed < 10)) {   // Set the fan higher
+      digitalWrite(gpio_up_pin, HIGH);
+      delay(100);
+      digitalWrite(gpio_up_pin, LOW);
+      delay(100);
+      ++actual_fan_speed; // Increment tracker for actual speed
+      ESP_LOGD(TAG, "Speed changed to: %d", actual_fan_speed);
+    }
+  } else if (FanSet < actual_fan_speed) {  
+    while ((FanSet < actual_fan_speed) && (actual_fan_speed > 1)) {   // Set the fan lower
+      digitalWrite(gpio_down_pin, HIGH);
+      delay(100);
+      digitalWrite(gpio_down_pin, LOW);
+      delay(100);
+      --actual_fan_speed; // Decrement tracker for actual speed
+      ESP_LOGD(TAG, "Speed changed to: %d", actual_fan_speed);
+    }
+  }
+}
+
+void PowerOutput::setup() {
+  pinMode(gpio_power_pin, OUTPUT);
+  ESP_LOGD(TAG, "PowerOutput setup complete");
+}
+
+void PowerOutput::write_state(bool FanSet) {
+  // Don't do anything if still booting or if request already matches actual 
+  if (FanSet != actual_fan_power && is_boot_finished) {
+    digitalWrite(gpio_power_pin, HIGH);
+    delay(100);
+    digitalWrite(gpio_power_pin, LOW);
+    actual_fan_power = FanSet;
+    actual_fan_cover = FanSet; // Maxxfan automatically changes cover on power action
+    
+    // Access the switch entity from the yaml configuration to publish state
+    for (auto *sw : App.get_switches()) {
+      if (sw->get_name() == "Cover") {
+        maxxfan_cover = sw;
+        break;
+      }
+    }
+    
+    if (maxxfan_cover != nullptr) {
+      maxxfan_cover->publish_state(FanSet);  // Update front end
+    }
+    
+    ESP_LOGD(TAG, "Power changed to: %s", actual_fan_power ? "On" : "Off");
+    ESP_LOGD(TAG, "Cover changed to: %s", actual_fan_cover ? "Open" : "Close");
+  }
+}
+
+void DirectionOutput::setup() {
+  pinMode(gpio_direction_pin, OUTPUT);
+  ESP_LOGD(TAG, "DirectionOutput setup complete");
+}
+
+void DirectionOutput::write_state(bool FanSet) {
+  // Don't do anything if still booting, or if request already matches actual
+  // or if power is turned off  
+  if ((FanSet != actual_fan_direction) && (actual_fan_power != 0) && is_boot_finished) {
+    digitalWrite(gpio_direction_pin, HIGH);
+    delay(100);
+    digitalWrite(gpio_direction_pin, LOW);
+    actual_fan_direction = FanSet;
+    ESP_LOGD(TAG, "Direction changed to: %s", actual_fan_direction ? "Reverse" : "Forward");
+  }
+}
+
+void CoverOutput::setup() {
+  pinMode(gpio_up_pin, OUTPUT);
+  pinMode(gpio_down_pin, OUTPUT);
+  
+  // Find and store a reference to the maxxfan_cover switch entity
+  for (auto *sw : App.get_switches()) {
+    if (sw->get_name() == "Cover") {
+      maxxfan_cover = sw;
+      break;
+    }
+  }
+  
+  ESP_LOGD(TAG, "CoverOutput setup complete");
+}
+
+void CoverOutput::write_state(bool FanSet) {
+  // Don't do anything if still booting or if request already matches actual 
+  if (FanSet != actual_fan_cover && is_boot_finished) {
+    // Need to simultaneously press the up and down buttons
+    digitalWrite(gpio_up_pin, HIGH);
+    digitalWrite(gpio_down_pin, HIGH);
+    delay(200);
+    digitalWrite(gpio_up_pin, LOW);
+    digitalWrite(gpio_down_pin, LOW);
+    actual_fan_cover = FanSet;
+    ESP_LOGD(TAG, "Cover changed to: %s", actual_fan_cover ? "Open" : "Close");
+  }
+}
+
+}  // namespace maxxfan
+}  // namespace esphome

--- a/homeassistant/esphome/components/maxxfan/maxxfan_output.h
+++ b/homeassistant/esphome/components/maxxfan/maxxfan_output.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/output/float_output.h"
+#include "esphome/components/output/binary_output.h"
+#include "esphome/components/switch/switch.h"
+
+namespace esphome {
+namespace maxxfan {
+
+// Define global variables
+extern int gpio_up_pin;
+extern int gpio_down_pin;
+extern int gpio_power_pin;
+extern int gpio_direction_pin;
+extern int gpio_auto_pin;
+extern int actual_fan_speed;
+extern bool actual_fan_power;
+extern bool actual_fan_direction;
+extern bool actual_fan_cover;
+extern bool is_boot_finished;
+
+class SpeedOutput : public Component, public output::FloatOutput {
+ public:
+  void setup() override;
+  void write_state(float state) override;
+};
+
+class PowerOutput : public Component, public output::BinaryOutput {
+ public:
+  void setup() override;
+  void write_state(bool state) override;
+};
+
+class DirectionOutput : public Component, public output::BinaryOutput {
+ public:
+  void setup() override;
+  void write_state(bool state) override;
+};
+
+class CoverOutput : public Component, public output::BinaryOutput {
+ public:
+  void setup() override;
+  void write_state(bool state) override;
+};
+
+}  // namespace maxxfan
+}  // namespace esphome

--- a/homeassistant/esphome/components/maxxfan/output.py
+++ b/homeassistant/esphome/components/maxxfan/output.py
@@ -1,0 +1,60 @@
+"""MaxxFan output component for ESPHome."""
+
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import output
+from esphome.const import CONF_ID, CONF_TYPE
+
+from . import maxxfan_ns
+
+# Define the output classes
+SpeedOutput = maxxfan_ns.class_("SpeedOutput", cg.Component, output.FloatOutput)
+PowerOutput = maxxfan_ns.class_("PowerOutput", cg.Component, output.BinaryOutput)
+DirectionOutput = maxxfan_ns.class_("DirectionOutput", cg.Component, output.BinaryOutput)
+CoverOutput = maxxfan_ns.class_("CoverOutput", cg.Component, output.BinaryOutput)
+
+# Configuration schema for each output type
+SPEED_OUTPUT_SCHEMA = output.FLOAT_OUTPUT_SCHEMA.extend({
+    cv.GenerateID(): cv.declare_id(SpeedOutput),
+}).extend(cv.COMPONENT_SCHEMA)
+
+POWER_OUTPUT_SCHEMA = output.BINARY_OUTPUT_SCHEMA.extend({
+    cv.GenerateID(): cv.declare_id(PowerOutput),
+}).extend(cv.COMPONENT_SCHEMA)
+
+DIRECTION_OUTPUT_SCHEMA = output.BINARY_OUTPUT_SCHEMA.extend({
+    cv.GenerateID(): cv.declare_id(DirectionOutput),
+}).extend(cv.COMPONENT_SCHEMA)
+
+COVER_OUTPUT_SCHEMA = output.BINARY_OUTPUT_SCHEMA.extend({
+    cv.GenerateID(): cv.declare_id(CoverOutput),
+}).extend(cv.COMPONENT_SCHEMA)
+
+# Register the output platforms
+CONFIG_SCHEMA = cv.Schema({
+    cv.Optional("speed"): SPEED_OUTPUT_SCHEMA,
+    cv.Optional("power"): POWER_OUTPUT_SCHEMA,
+    cv.Optional("direction"): DIRECTION_OUTPUT_SCHEMA,
+    cv.Optional("cover"): COVER_OUTPUT_SCHEMA,
+})
+
+async def to_code(config):
+    if "speed" in config:
+        var = cg.new_Pvariable(config["speed"][CONF_ID])
+        await cg.register_component(var, config["speed"])
+        await output.register_output(var, config["speed"])
+
+    if "power" in config:
+        var = cg.new_Pvariable(config["power"][CONF_ID])
+        await cg.register_component(var, config["power"])
+        await output.register_output(var, config["power"])
+
+    if "direction" in config:
+        var = cg.new_Pvariable(config["direction"][CONF_ID])
+        await cg.register_component(var, config["direction"])
+        await output.register_output(var, config["direction"])
+
+    if "cover" in config:
+        var = cg.new_Pvariable(config["cover"][CONF_ID])
+        await cg.register_component(var, config["cover"])
+        await output.register_output(var, config["cover"])

--- a/homeassistant/esphome/maxxfan-lite.yaml
+++ b/homeassistant/esphome/maxxfan-lite.yaml
@@ -1,8 +1,6 @@
 esphome:
   name: maxxfan
   friendly_name: MaxxFan
-  includes:
-    - custom_outputs.h
   on_boot:
     # Lowest priority; wait until everything else is done
     priority: -100
@@ -157,6 +155,13 @@ globals:
     initial_value: "5"
     restore_value: no
 
+# Register the external component
+external_components:
+  - source:
+      type: local
+      path: components
+    components: [maxxfan]
+
 fan:
   # Main fan entity for power and speed
   - platform: speed
@@ -176,42 +181,17 @@ fan:
       output.turn_off: output_power
 
 output:
-  # Custom output for when power changed
-  - platform: custom
-    type: binary
-    lambda: |-
-      auto my_power_output = new PowerOutput();
-      App.register_component(my_power_output);
-      return {my_power_output};
-    outputs:
+  # Use our external component for outputs
+  - platform: maxxfan
+    power:
       id: output_power
-  # Custom output for when speed changed
-  - platform: custom
-    type: float
-    lambda: |-
-      auto my_speed_output = new SpeedOutput();
-      App.register_component(my_speed_output);
-      return {my_speed_output};
-    outputs:
+    speed:
       id: output_speed
-  # Custom output for when direction changed
-  - platform: custom
-    type: binary
-    lambda: |-
-      auto my_direction_output = new DirectionOutput();
-      App.register_component(my_direction_output);
-      return {my_direction_output};
-    outputs:
+    direction:
       id: output_direction
-  # Custom output for when cover changed
-  - platform: custom
-    type: binary
-    lambda: |-
-      auto my_cover_output = new CoverOutput();
-      App.register_component(my_cover_output);
-      return {my_cover_output};
-    outputs:
+    cover:
       id: output_cover
+
 switch:
   # Switch for controlling cover open/close.
   - platform: output


### PR DESCRIPTION
Fixes #11 #9 

# Convert MaxxFan custom outputs to external component

## Description

This PR converts the previously deprecated custom output components in ESPHome to the recommended external component structure. ESPHome 2025.3.3 has removed support for the "custom" component, requiring this conversion.

> NOTE: This code was all written by GH Copliot Agent mode with Claude 3.7 Sonnet.?
> It took several iterations, but I helped it very little.


## Changes

- Created an external component directory structure in `components/maxxfan/`
- Implemented four key output components:
  - `SpeedOutput`: Controls fan speed (1-10) using UP/DOWN buttons
  - `PowerOutput`: Controls fan power using the POWER button
  - `DirectionOutput`: Controls air flow direction using the DIRECTION button
  - `CoverOutput`: Controls lid position using simultaneous UP/DOWN buttons
- Preserved all existing functionality from the original implementation
- Maintained the use of GPIO pin configurations from the YAML file
- Left the original custom_outputs.h file untouched for reference

## Technical Details

- Created Python modules for component registration and configuration validation
- Implemented C++ classes that inherit from ESPHome's output interfaces
- Added necessary Arduino includes for GPIO handling
- Created properly defined global variables for state tracking
- Connected the external component to the YAML configuration globals

## Testing

Tested successfully with ESPHome 2025.3.3 on an ESP32 controller. The device maintains all previous functionality while using the current best practices for ESPHome component development.

## Related Issues

Fixes the "The 'custom' component has been removed" error introduced in ESPHome 2025.3.3.